### PR TITLE
Working with JMS Text/Bytes Messages

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -162,6 +162,20 @@ class TestTorStomp(AsyncTestCase):
             b'SEND\ncontent-length:14\ndestination:/topic/test\n'
             b'my-header:my-value\n\nWilson J\xc3\xbanior\x00')
 
+    def test_jms_compatible_send_write_in_stream(self):
+        self.stomp.stream = MagicMock()
+        self.stomp.send('/topic/test', headers={
+            'my-header': 'my-value',
+        }, body='{}', send_content_length=False)
+
+        self.assertEqual(self.stomp.stream.write.call_count, 1)
+        self.assertEqual(
+            self.stomp.stream.write.call_args[0][0],
+            b'SEND\n'
+            b'destination:/topic/test\n'
+            b'my-header:my-value\n\n'
+            b'{}\x00')
+
     def test_set_heart_beat_integration(self):
         self.stomp._set_heart_beat = MagicMock()
         self.stomp._on_data(

--- a/torstomp/__init__.py
+++ b/torstomp/__init__.py
@@ -89,12 +89,16 @@ class TorStomp(object):
         if self.connected:
             self._send_subscribe_frame(subscription)
 
-    def send(self, destination, body='', headers={}):
+    def send(self, destination, body='', headers={}, send_content_length=True):
         headers['destination'] = destination
 
         if body:
             body = self._protocol._encode(body)
-            headers['content-length'] = len(body)
+
+            # ActiveMQ determines the type of a message by the
+            # inclusion of the content-length header
+            if send_content_length:
+                headers['content-length'] = len(body)
 
         return self._send_frame('SEND', headers, body)
 


### PR DESCRIPTION
We are sending messages to ActiveMQ with the `content-length` header. Following the ActiveMQ/Stomp documentation (http://activemq.apache.org/stomp.html), when we fill this header the service infers that the message is a `BytesMessage`.

I have a Consumer (wrote in Java) waiting for a `TextMessage` instead...
